### PR TITLE
Enable serde and Clone on RandomForest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ name = "biosphere"
 ndarray = "0.16.1"
 rand = "0.8"
 rayon = "1.10"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
 
 [profile.bench]
 incremental = true

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -8,9 +8,11 @@ use rand::Rng;
 use rand::SeedableRng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPoolBuilder;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct RandomForestParameters {
     decision_tree_parameters: DecisionTreeParameters,
     n_estimators: usize,
@@ -97,7 +99,8 @@ impl RandomForestParameters {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone)]
 pub struct RandomForest {
     random_forest_parameters: RandomForestParameters,
     trees: Vec<DecisionTree>,

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -8,8 +8,9 @@ use rand::Rng;
 use rand::SeedableRng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPoolBuilder;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RandomForestParameters {
     decision_tree_parameters: DecisionTreeParameters,
     n_estimators: usize,
@@ -96,6 +97,7 @@ impl RandomForestParameters {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RandomForest {
     random_forest_parameters: RandomForestParameters,
     trees: Vec<DecisionTree>,

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -4,9 +4,11 @@ use crate::utils::sorted_samples;
 use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone)]
 pub struct DecisionTree {
     decision_tree_parameters: DecisionTreeParameters,
     node: DecisionTreeNode,

--- a/src/tree/decision_tree.rs
+++ b/src/tree/decision_tree.rs
@@ -4,7 +4,9 @@ use crate::utils::sorted_samples;
 use ndarray::{Array1, ArrayView1, ArrayView2};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DecisionTree {
     decision_tree_parameters: DecisionTreeParameters,
     node: DecisionTreeNode,

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -2,12 +2,13 @@ use crate::tree::DecisionTreeParameters;
 use ndarray::{ArrayView1, ArrayView2};
 use rand::seq::SliceRandom;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 use std::debug_assert;
 
 static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
 static FEATURE_THRESHOLD: f64 = 1e-14;
 
-#[derive(Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct DecisionTreeNode {
     pub left_child: Option<Box<DecisionTreeNode>>,
     pub right_child: Option<Box<DecisionTreeNode>>,

--- a/src/tree/decision_tree_node.rs
+++ b/src/tree/decision_tree_node.rs
@@ -2,13 +2,15 @@ use crate::tree::DecisionTreeParameters;
 use ndarray::{ArrayView1, ArrayView2};
 use rand::seq::SliceRandom;
 use rand::Rng;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::debug_assert;
 
 static MIN_GAIN_TO_SPLIT: f64 = 1e-12;
 static FEATURE_THRESHOLD: f64 = 1e-14;
 
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Default)]
 pub struct DecisionTreeNode {
     pub left_child: Option<Box<DecisionTreeNode>>,
     pub right_child: Option<Box<DecisionTreeNode>>,

--- a/src/tree/decision_tree_parameters.rs
+++ b/src/tree/decision_tree_parameters.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Default)]
 pub enum MaxFeatures {
     // Consider all `d` features at each split.
     #[default]
@@ -12,7 +14,7 @@ pub enum MaxFeatures {
     // Consider `int(sqrt(d))` features at each split.
     Sqrt,
     // Consider `callable(d)` features at each split. Skipped in Serialize/Deserialize.
-    #[serde(skip_serializing, skip_deserializing)]
+    #[cfg_attr(feature = "serde", serde(skip_serializing, skip_deserializing))]
     Callable(fn(usize) -> usize),
 }
 
@@ -30,7 +32,8 @@ impl MaxFeatures {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct DecisionTreeParameters {
     // Maximum depth of the tree. If `None`, nodes are expanded until all leaves are
     // pure or contain fewer than `min_samples_split` samples.

--- a/src/tree/decision_tree_parameters.rs
+++ b/src/tree/decision_tree_parameters.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Debug, Default)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum MaxFeatures {
     // Consider all `d` features at each split.
     #[default]
@@ -9,7 +11,8 @@ pub enum MaxFeatures {
     Value(usize),
     // Consider `int(sqrt(d))` features at each split.
     Sqrt,
-    // Consider `callable(d)` features at each split.
+    // Consider `callable(d)` features at each split. Skipped in Serialize/Deserialize.
+    #[serde(skip_serializing, skip_deserializing)]
     Callable(fn(usize) -> usize),
 }
 
@@ -27,7 +30,7 @@ impl MaxFeatures {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DecisionTreeParameters {
     // Maximum depth of the tree. If `None`, nodes are expanded until all leaves are
     // pure or contain fewer than `min_samples_split` samples.


### PR DESCRIPTION
## Summary
- support serialization for tree structs
- derive `Clone`, `Serialize`, and `Deserialize` for `RandomForest`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6868b999b8308321939d32638ba0ec07